### PR TITLE
El problema en parte se arreglo..

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ sea-orm = { version = "0.12.14", features = [
     "runtime-tokio-rustls",
     "macros",
 ] }
-sea-orm-migration = "0.9"
+sea-orm-migration = "0.12.14"
 async-trait = "0.1"
 
 #serde


### PR DESCRIPTION
La version de sea-orm-migration era la 0.9, cuando la versión de sea-orm es de 0.12.14, y ahi se producía un error de conflicto entre versiones. 
Limpie y volví a copilar.. y como digo, en parte se soluciono.